### PR TITLE
Fix admin panel mixed content

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -28,6 +28,7 @@ async def start_web() -> None:
         host=settings.app_host,
         port=settings.app_port,
         log_level=settings.log_level.lower(),
+        forwarded_allow_ips="*",
     )
     server = uvicorn.Server(config)
     logger.info("Starting FastAPI on %s:%s", settings.app_host, settings.app_port)


### PR DESCRIPTION
## Summary
- Добавлен `forwarded_allow_ips="*"` в uvicorn config, чтобы proxy headers (X-Forwarded-Proto) от Traefik в Docker-сети обрабатывались корректно
- Без этого uvicorn доверяет только `127.0.0.1`, а Traefik приходит с IP Docker-сети — заголовок `X-Forwarded-Proto: https` игнорировался, и все URL (включая стили sqladmin) генерировались с `http://`, вызывая Mixed Content блокировку

Closes #2