### PR TITLE
Auto-seed strategies on startup

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -6,6 +6,7 @@ import uvicorn
 
 from app.bot import bot, dp
 from app.config import settings
+from app.utils.seed import seed_strategies
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,10 @@ async def main() -> None:
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, _signal_handler)
+
+    count = await seed_strategies()
+    if count:
+        logger.info("Seeded %d strategies", count)
 
     try:
         await asyncio.gather(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -724,7 +724,24 @@ class TestWorkerTasks:
 
 
 # =====================================================================
-# E2E FLOW 10: Date Utils
+# E2E FLOW 10: Strategy Seeding
+# =====================================================================
+
+
+class TestStrategySeeding:
+    """Test automatic strategy seeding on startup."""
+
+    async def test_seed_strategies_idempotent(self, session: AsyncSession):
+        """Second call returns 0 when all strategies already exist."""
+        from app.utils.seed import seed_strategies
+
+        await seed_strategies()
+        second = await seed_strategies()
+        assert second == 0
+
+
+# =====================================================================
+# E2E FLOW 11: Date Utils
 # =====================================================================
 
 


### PR DESCRIPTION
## Summary
- При запуске приложения вызывается `seed_strategies()` перед стартом бота и FastAPI
- Функция идемпотентна: проверяет по `name_en`, создает только отсутствующие стратегии
- На пустой БД засеет 16 стратегий, на заполненной - ничего не сделает

## Test plan
- [x] Тест идемпотентности: два вызова подряд, второй возвращает 0
- [x] 375 passed, 1 skipped, ruff clean

Closes #24