### PR TITLE
feat: block event/wish creation early when free tier limit exceeded

### DIFF
--- a/app/handlers/events.py
+++ b/app/handlers/events.py
@@ -280,8 +280,26 @@ async def event_wish_list(
 async def event_create_start(
     callback: CallbackQuery,
     state: FSMContext,
+    user: User,
     lang: str,
+    session: AsyncSession,
 ) -> None:
+    from app.services.app_settings_service import get_int_setting
+    from app.services.event_service import count_user_events
+    from app.services.subscription_service import has_active_subscription
+
+    max_events = await get_int_setting(session, "default_max_events", user.max_events)
+    count = await count_user_events(session, user.id)
+    if count >= max_events and not await has_active_subscription(session, user.id):
+        from app.keyboards.subscription import upgrade_kb
+
+        await callback.message.edit_text(  # type: ignore[union-attr]
+            t("events.limit_reached", lang, max=str(max_events)),
+            reply_markup=upgrade_kb(lang),
+        )
+        await callback.answer()
+        return
+
     await callback.message.edit_text(  # type: ignore[union-attr]
         t("events.create_title", lang),
         reply_markup=cancel_kb(lang),

--- a/app/handlers/wishes.py
+++ b/app/handlers/wishes.py
@@ -126,8 +126,25 @@ async def wish_view(
 async def wish_create_start(
     callback: CallbackQuery,
     state: FSMContext,
+    user: User,
     lang: str,
+    session: AsyncSession,
 ) -> None:
+    from app.services.app_settings_service import get_int_setting
+    from app.services.subscription_service import has_active_subscription
+
+    max_wishes = await get_int_setting(session, "default_max_wishes", user.max_wishes)
+    count = await count_user_wishes(session, user.id)
+    if count >= max_wishes and not await has_active_subscription(session, user.id):
+        from app.keyboards.subscription import upgrade_kb
+
+        await callback.message.edit_text(  # type: ignore[union-attr]
+            t("wishes.limit_reached", lang, max=str(max_wishes)),
+            reply_markup=upgrade_kb(lang),
+        )
+        await callback.answer()
+        return
+
     await callback.message.edit_text(  # type: ignore[union-attr]
         t("wishes.create_text", lang),
         reply_markup=cancel_kb(lang),

--- a/tests/test_free_limits.py
+++ b/tests/test_free_limits.py
@@ -389,3 +389,193 @@ class TestNotificationTeaser:
 
         assert result is True
         self.mock_bot.send_message.assert_called_once()
+
+
+class TestEventCreateLimit:
+    async def test_blocked_when_over_limit(self):
+        from app.handlers.events import event_create_start
+
+        callback = AsyncMock()
+        callback.from_user = MagicMock(id=100)
+        callback.message = AsyncMock()
+        state = AsyncMock()
+        user = _make_mock_user(max_events=5)
+        session = AsyncMock()
+
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.services.event_service.count_user_events",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "app.services.subscription_service.has_active_subscription",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await event_create_start(callback, state, user, "ru", session)
+
+        callback.message.edit_text.assert_called_once()
+        call_args = callback.message.edit_text.call_args
+        assert "5" in call_args.args[0]
+        state.set_state.assert_not_called()
+
+    async def test_allowed_when_under_limit(self):
+        from app.handlers.events import event_create_start
+
+        callback = AsyncMock()
+        callback.from_user = MagicMock(id=100)
+        callback.message = AsyncMock()
+        callback.message.message_id = 42
+        state = AsyncMock()
+        user = _make_mock_user(max_events=10)
+        session = AsyncMock()
+
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.services.event_service.count_user_events",
+                new_callable=AsyncMock,
+                return_value=3,
+            ),
+        ):
+            await event_create_start(callback, state, user, "ru", session)
+
+        state.set_state.assert_called_once()
+
+    async def test_allowed_with_subscription(self):
+        from app.handlers.events import event_create_start
+
+        callback = AsyncMock()
+        callback.from_user = MagicMock(id=100)
+        callback.message = AsyncMock()
+        callback.message.message_id = 42
+        state = AsyncMock()
+        user = _make_mock_user(max_events=5)
+        session = AsyncMock()
+
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.services.event_service.count_user_events",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "app.services.subscription_service.has_active_subscription",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await event_create_start(callback, state, user, "ru", session)
+
+        state.set_state.assert_called_once()
+
+
+class TestWishCreateLimit:
+    async def test_blocked_when_over_limit(self):
+        from app.handlers.wishes import wish_create_start
+
+        callback = AsyncMock()
+        callback.from_user = MagicMock(id=100)
+        callback.message = AsyncMock()
+        state = AsyncMock()
+        user = _make_mock_user(max_wishes=5)
+        session = AsyncMock()
+
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.handlers.wishes.count_user_wishes",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "app.services.subscription_service.has_active_subscription",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await wish_create_start(callback, state, user, "ru", session)
+
+        callback.message.edit_text.assert_called_once()
+        call_args = callback.message.edit_text.call_args
+        assert "5" in call_args.args[0]
+        state.set_state.assert_not_called()
+
+    async def test_allowed_when_under_limit(self):
+        from app.handlers.wishes import wish_create_start
+
+        callback = AsyncMock()
+        callback.from_user = MagicMock(id=100)
+        callback.message = AsyncMock()
+        callback.message.message_id = 42
+        state = AsyncMock()
+        user = _make_mock_user(max_wishes=10)
+        session = AsyncMock()
+
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.handlers.wishes.count_user_wishes",
+                new_callable=AsyncMock,
+                return_value=3,
+            ),
+        ):
+            await wish_create_start(callback, state, user, "ru", session)
+
+        state.set_state.assert_called_once()
+
+    async def test_allowed_with_subscription(self):
+        from app.handlers.wishes import wish_create_start
+
+        callback = AsyncMock()
+        callback.from_user = MagicMock(id=100)
+        callback.message = AsyncMock()
+        callback.message.message_id = 42
+        state = AsyncMock()
+        user = _make_mock_user(max_wishes=5)
+        session = AsyncMock()
+
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.handlers.wishes.count_user_wishes",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "app.services.subscription_service.has_active_subscription",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await wish_create_start(callback, state, user, "ru", session)
+
+        state.set_state.assert_called_once()

--- a/tests/test_user_scenarios.py
+++ b/tests/test_user_scenarios.py
@@ -189,16 +189,32 @@ class TestEventCRUD:
 
     async def test_07_event_create_starts_fsm(self, session: AsyncSession):
         """S07: Press 'create event' → FSM state waiting_title, cancel button shown."""
+        from unittest.mock import patch
+
         from app.handlers.events import event_create_start
 
         cb = _mock_callback()
         state = _mock_state()
+        user = AsyncMock()
+        user.id = 100
+        user.max_events = 10
 
-        await event_create_start(cb, state, "ru")
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.services.event_service.count_user_events",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+        ):
+            await event_create_start(cb, state, user, "ru", session)
 
         cb.message.edit_text.assert_called_once()
         state.set_state.assert_called_once()
-        # Verify cancel keyboard is present
         kw = cb.message.edit_text.call_args.kwargs
         assert "reply_markup" in kw
 
@@ -356,12 +372,29 @@ class TestWishCRUD:
 
     async def test_17_wish_create_starts_fsm(self, session: AsyncSession):
         """S17: Press 'create wish' → waiting_text state with cancel button."""
+        from unittest.mock import patch
+
         from app.handlers.wishes import wish_create_start
 
         cb = _mock_callback()
         state = _mock_state()
+        user = AsyncMock()
+        user.id = 100
+        user.max_wishes = 10
 
-        await wish_create_start(cb, state, "ru")
+        with (
+            patch(
+                "app.services.app_settings_service.get_int_setting",
+                new_callable=AsyncMock,
+                side_effect=lambda session, key, default: default,
+            ),
+            patch(
+                "app.handlers.wishes.count_user_wishes",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+        ):
+            await wish_create_start(cb, state, user, "ru", session)
 
         state.set_state.assert_called_once()
         kw = cb.message.edit_text.call_args.kwargs


### PR DESCRIPTION
## Summary

- Проверка лимита добавлена в начало `event_create_start` и `wish_create_start` - пользователь сразу получает сообщение о необходимости подписки вместо прохождения всего визарда создания
- AI-flow не затронут: там пользователь отправляет одно сообщение, и ошибка ловится сразу при попытке создания
- 6 новых тестов покрывают блокировку и пропуск проверки при наличии подписки
- Обновлены 2 существующих теста под новые сигнатуры handlers

## Test plan

- [x] `uv run ruff check app/ tests/` - чисто
- [x] `uv run ruff format --check app/ tests/` - чисто
- [x] `uv run python -m pytest -q` - 511 passed, 1 skipped

Closes #35