### PR TITLE
Replace skip emoji with text in onboarding

### DIFF
--- a/app/keyboards/main_menu.py
+++ b/app/keyboards/main_menu.py
@@ -29,7 +29,7 @@ def onboarding_event_kb(lang: str) -> InlineKeyboardMarkup:
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="\u23ed",
+                    text=t("onboarding.skip", lang),
                     callback_data=OnboardCb(action="skip").pack(),
                 )
             ],
@@ -44,7 +44,7 @@ def onboarding_skip_kb(lang: str) -> InlineKeyboardMarkup:
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="\u23ed",
+                    text=t("onboarding.skip", lang),
                     callback_data=OnboardCb(action="skip").pack(),
                 )
             ],

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -182,13 +182,13 @@ class TestMainMenuKeyboard:
         assert len(kb.inline_keyboard) == 1
         assert kb.inline_keyboard[0][0].callback_data == "cancel"
 
-    def test_onboarding_skip_kb_emoji_only(self):
+    def test_onboarding_skip_kb_text(self):
         from app.keyboards.main_menu import onboarding_skip_kb
 
         kb = onboarding_skip_kb("en")
         assert len(kb.inline_keyboard) == 1
         btn = kb.inline_keyboard[0][0]
-        assert btn.text == "\u23ed"
+        assert btn.text == "Skip"
         assert "onb:" in btn.callback_data
 
     def test_onboarding_event_kb_skip_button(self):


### PR DESCRIPTION
## Summary
- Replaced emoji ⏭ with localized text ("Пропустить" / "Skip") in onboarding skip buttons
- Updated corresponding test assertion

Closes #36