### PR TITLE
Send notification to referrer on referral activation

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -55,7 +55,16 @@ async def cmd_start(
                     await session.flush()
                     from app.services.referral_service import process_referral
 
-                    await process_referral(session, referrer_id, user.id)
+                    reward_months = await process_referral(session, referrer_id, user.id)
+                    if reward_months is not None:
+                        try:
+                            referrer_lang = referrer.language or "ru"
+                            await message.bot.send_message(
+                                referrer_id,
+                                t("subscription.referral_bonus", referrer_lang, months=reward_months),
+                            )
+                        except Exception:
+                            logger.warning("Failed to send referral notification to %d", referrer_id)
         except ValueError:
             logger.warning("Invalid referral args: %s", command.args)
         except Exception:

--- a/app/services/referral_service.py
+++ b/app/services/referral_service.py
@@ -10,8 +10,8 @@ from app.models.referral_reward import ReferralReward
 logger = logging.getLogger(__name__)
 
 
-async def process_referral(session: AsyncSession, referrer_id: int, referred_id: int) -> bool:
-    """Grant referral bonus to referrer. Returns True if bonus was granted."""
+async def process_referral(session: AsyncSession, referrer_id: int, referred_id: int) -> int | None:
+    """Grant referral bonus to referrer. Returns reward months or None if already processed."""
     from app.services.app_settings_service import get_int_setting
     from app.services.subscription_service import grant_subscription
 
@@ -19,7 +19,7 @@ async def process_referral(session: AsyncSession, referrer_id: int, referred_id:
         select(ReferralReward).where(ReferralReward.referred_id == referred_id)
     )
     if existing.scalar_one_or_none() is not None:
-        return False
+        return None
 
     reward_months = await get_int_setting(session, "referral_reward_months", 1)
 
@@ -38,7 +38,7 @@ async def process_referral(session: AsyncSession, referrer_id: int, referred_id:
         referrer_id,
         referred_id,
     )
-    return True
+    return reward_months
 
 
 def get_referral_link(bot_username: str, user_id: int) -> str:

--- a/tests/test_services/test_referral_service.py
+++ b/tests/test_services/test_referral_service.py
@@ -26,7 +26,7 @@ async def test_process_referral(session: AsyncSession):
     referred = await _create_test_user(session, 222)
 
     result = await process_referral(session, referrer.id, referred.id)
-    assert result is True
+    assert result == 1
     assert await has_active_subscription(session, referrer.id) is True
 
 
@@ -37,7 +37,7 @@ async def test_process_referral_duplicate(session: AsyncSession):
 
     await process_referral(session, referrer.id, referred.id)
     result = await process_referral(session, referrer.id, referred.id)
-    assert result is False
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_scenarios.py
+++ b/tests/test_user_scenarios.py
@@ -922,3 +922,50 @@ class TestEdgeCases:
         state.clear.assert_called_once()
         text = msg.answer.call_args.args[0]
         assert "найдено" in text.lower() or "found" in text.lower()
+
+
+class TestReferralNotification:
+
+    @patch("app.services.referral_service.process_referral", new_callable=AsyncMock, return_value=2)
+    @patch("app.handlers.start.log_user_action", new_callable=AsyncMock)
+    async def test_referral_sends_notification_to_referrer(
+        self, _mock_log, _mock_process, session: AsyncSession
+    ):
+        from app.handlers.start import cmd_start
+
+        await _make_user(session, user_id=111, language="en")
+        user = await _make_user(session, user_id=222, onboarding_completed=True)
+
+        msg = _mock_message("/start")
+        msg.bot = AsyncMock()
+        msg.bot.send_message = AsyncMock()
+        state = _mock_state()
+        command = MagicMock()
+        command.args = "ref_111"
+
+        await cmd_start(msg, state, user, "ru", session, command=command)
+
+        msg.bot.send_message.assert_called_once()
+        call_args = msg.bot.send_message.call_args
+        assert call_args.args[0] == 111
+        assert "2" in call_args.args[1]
+
+    @patch("app.handlers.start.log_user_action", new_callable=AsyncMock)
+    async def test_referral_no_notification_on_duplicate(self, _mock_log, session: AsyncSession):
+        from app.handlers.start import cmd_start
+
+        await _make_user(session, user_id=111, language="ru")
+        user = await _make_user(session, user_id=222, onboarding_completed=True)
+        user.referred_by = 111
+        await session.flush()
+
+        msg = _mock_message("/start")
+        msg.bot = AsyncMock()
+        msg.bot.send_message = AsyncMock()
+        state = _mock_state()
+        command = MagicMock()
+        command.args = "ref_111"
+
+        await cmd_start(msg, state, user, "ru", session, command=command)
+
+        msg.bot.send_message.assert_not_called()


### PR DESCRIPTION
## Summary
- When a new user registers via referral link, the referrer now receives a bot message with the reward months
- Uses existing `subscription.referral_bonus` i18n key (was defined but unused)
- `process_referral()` now returns reward months (int) or None instead of bool
- Notification failure is caught and logged without breaking the registration flow

## Test plan
- [x] Test: referral sends notification to referrer with correct user_id and reward text
- [x] Test: duplicate referral does not send notification
- [x] All 513 tests pass

Closes #37