### PR TITLE
feat: admin dashboard and hidden id columns

### DIFF
--- a/app/admin/setup.py
+++ b/app/admin/setup.py
@@ -1,13 +1,14 @@
 """sqladmin setup with session-based auth + clear-db action + test notifications."""
 
 import logging
+from datetime import UTC, datetime, timedelta
 
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqladmin import Admin
 from sqladmin._menu import ItemMenu
 from sqladmin.authentication import AuthenticationBackend
-from sqlalchemy import text
+from sqlalchemy import Date, cast, func, select, text
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.requests import Request
 
@@ -62,6 +63,94 @@ def setup_admin(app: FastAPI) -> Admin:
     app.add_middleware(SessionMiddleware, secret_key=settings.admin_secret_key)
 
     # --- Custom endpoints MUST be registered BEFORE Admin() mount ---
+
+    @app.get("/admin/dashboard", response_class=HTMLResponse)
+    async def dashboard_page(request: Request) -> HTMLResponse:
+        if not request.session.get("authenticated"):
+            return RedirectResponse(url="/admin/login", status_code=302)  # type: ignore[return-value]
+
+        from app.models.event import Event
+        from app.models.payment import Payment
+        from app.models.subscription import Subscription
+        from app.models.user import User
+        from app.models.wish import Wish
+
+        now = datetime.now(UTC)
+        week_ago = now - timedelta(days=7)
+        month_ago = now - timedelta(days=30)
+
+        async with async_session_factory() as session:
+            total_users = (await session.execute(select(func.count(User.id)))).scalar() or 0
+            new_users_7d = (
+                await session.execute(
+                    select(func.count(User.id)).where(User.created_at >= week_ago)
+                )
+            ).scalar() or 0
+            new_users_30d = (
+                await session.execute(
+                    select(func.count(User.id)).where(User.created_at >= month_ago)
+                )
+            ).scalar() or 0
+
+            paying_users = (
+                await session.execute(
+                    select(func.count(func.distinct(Subscription.user_id))).where(
+                        Subscription.is_active.is_(True)
+                    )
+                )
+            ).scalar() or 0
+            free_users = total_users - paying_users
+
+            total_stars = (
+                await session.execute(select(func.coalesce(func.sum(Payment.amount_stars), 0)))
+            ).scalar() or 0
+
+            total_events = (await session.execute(select(func.count(Event.id)))).scalar() or 0
+            total_wishes = (await session.execute(select(func.count(Wish.id)))).scalar() or 0
+
+            avg_events = round(total_events / total_users, 1) if total_users else 0
+            avg_wishes = round(total_wishes / total_users, 1) if total_users else 0
+            wish_event_ratio = round(total_wishes / total_events, 2) if total_events else 0
+
+            growth_rows = (
+                await session.execute(
+                    select(
+                        cast(User.created_at, Date).label("day"),
+                        func.count(User.id).label("cnt"),
+                    )
+                    .where(User.created_at >= month_ago)
+                    .group_by(cast(User.created_at, Date))
+                    .order_by(cast(User.created_at, Date))
+                )
+            ).all()
+
+            growth_labels = [row.day.strftime("%d.%m") for row in growth_rows]
+            growth_data: list[int] = []
+            running = total_users - new_users_30d
+            for row in growth_rows:
+                running += row.cnt
+                growth_data.append(running)
+
+        rendered = await request.app.state.admin.templates.TemplateResponse(
+            request,
+            "dashboard.html",
+            {
+                "total_users": total_users,
+                "new_users_7d": new_users_7d,
+                "new_users_30d": new_users_30d,
+                "paying_users": paying_users,
+                "free_users": free_users,
+                "total_stars": total_stars,
+                "total_events": total_events,
+                "total_wishes": total_wishes,
+                "avg_events": avg_events,
+                "avg_wishes": avg_wishes,
+                "wish_event_ratio": wish_event_ratio,
+                "growth_labels": growth_labels,
+                "growth_data": growth_data,
+            },
+        )
+        return HTMLResponse(content=rendered.body, status_code=rendered.status_code)
 
     @app.get("/admin/stars-balance", response_class=HTMLResponse)
     async def stars_balance_page(request: Request) -> HTMLResponse:
@@ -369,6 +458,17 @@ def setup_admin(app: FastAPI) -> Admin:
     admin.add_view(AILogAdmin)
     admin.add_view(UserActionLogAdmin)
 
+    class DashboardMenuItem(ItemMenu):
+        @property
+        def type_(self) -> str:
+            return "View"
+
+        def url(self, request: Request) -> str:
+            return "/admin/dashboard"
+
+        def is_active(self, request: Request) -> bool:
+            return request.url.path == "/admin/dashboard"
+
     class StarsMenuItem(ItemMenu):
         @property
         def type_(self) -> str:
@@ -380,6 +480,7 @@ def setup_admin(app: FastAPI) -> Admin:
         def is_active(self, request: Request) -> bool:
             return request.url.path == "/admin/stars-balance"
 
+    admin._menu.items.insert(0, DashboardMenuItem(name="Dashboard", icon="fa-solid fa-chart-line"))
     admin._menu.items.append(StarsMenuItem(name="Stars Balance", icon="fa-solid fa-star"))
 
     app.state.admin = admin

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -20,7 +20,6 @@ from app.models.wish import Wish
 
 class UserAdmin(ModelView, model=User):
     column_list = [
-        User.id,
         User.username,
         User.first_name,
         User.language,
@@ -58,8 +57,9 @@ class UserAdmin(ModelView, model=User):
     icon = "fa-solid fa-users"
 
     column_formatters = {
-        User.id: lambda m, _: Markup(
-            f'{m.id} <a href="/admin/test-notify/{m.id}" '
+        User.username: lambda m, _: Markup(
+            f'{m.username or "-"}'
+            f' <a href="/admin/test-notify/{m.id}" '
             f'style="margin-left:8px;padding:2px 8px;background:#0d6efd;color:#fff;'
             f'border-radius:4px;text-decoration:none;font-size:12px">'
             f"\U0001f514 Test</a>"
@@ -73,7 +73,6 @@ class UserAdmin(ModelView, model=User):
 
 class EventAdmin(ModelView, model=Event):
     column_list = [
-        Event.id,
         Event.user_id,
         Event.title,
         Event.event_date,
@@ -91,7 +90,6 @@ class EventAdmin(ModelView, model=Event):
 
 class WishAdmin(ModelView, model=Wish):
     column_list = [
-        Wish.id,
         Wish.user_id,
         Wish.text,
         Wish.reminder_date,
@@ -108,7 +106,7 @@ class WishAdmin(ModelView, model=Wish):
 
 
 class PersonAdmin(ModelView, model=Person):
-    column_list = [Person.id, Person.user_id, Person.name, Person.created_at]
+    column_list = [Person.user_id, Person.name, Person.created_at]
     column_searchable_list = [Person.name]
     column_sortable_list = [Person.name, Person.created_at]
     form_excluded_columns = [Person.events, Person.wishes]
@@ -119,7 +117,6 @@ class PersonAdmin(ModelView, model=Person):
 
 class BeautifulDateStrategyAdmin(ModelView, model=BeautifulDateStrategy):
     column_list = [
-        BeautifulDateStrategy.id,
         BeautifulDateStrategy.name_en,
         BeautifulDateStrategy.strategy_type,
         BeautifulDateStrategy.is_active,
@@ -136,7 +133,6 @@ class BeautifulDateStrategyAdmin(ModelView, model=BeautifulDateStrategy):
 
 class BeautifulDateAdmin(ModelView, model=BeautifulDate):
     column_list = [
-        BeautifulDate.id,
         BeautifulDate.event_id,
         BeautifulDate.target_date,
         BeautifulDate.label_en,
@@ -154,7 +150,6 @@ class BeautifulDateAdmin(ModelView, model=BeautifulDate):
 
 class MediaLinkAdmin(ModelView, model=MediaLink):
     column_list = [
-        MediaLink.id,
         MediaLink.wish_id,
         MediaLink.media_type,
         MediaLink.is_deleted,
@@ -166,7 +161,6 @@ class MediaLinkAdmin(ModelView, model=MediaLink):
 
 class NotificationLogAdmin(ModelView, model=NotificationLog):
     column_list = [
-        NotificationLog.id,
         NotificationLog.user_id,
         NotificationLog.notification_type,
         NotificationLog.sent_at,
@@ -183,7 +177,6 @@ class NotificationLogAdmin(ModelView, model=NotificationLog):
 
 class AILogAdmin(ModelView, model=AILog):
     column_list = [
-        AILog.id,
         AILog.user_id,
         AILog.agent_name,
         AILog.model,
@@ -220,7 +213,6 @@ class AILogAdmin(ModelView, model=AILog):
 
 class UserActionLogAdmin(ModelView, model=UserActionLog):
     column_list = [
-        UserActionLog.id,
         UserActionLog.user_id,
         UserActionLog.action,
         UserActionLog.detail,
@@ -272,7 +264,6 @@ class AppSettingsAdmin(ModelView, model=AppSettings):
 
 class SubscriptionPlanAdmin(ModelView, model=SubscriptionPlan):
     column_list = [
-        SubscriptionPlan.id,
         SubscriptionPlan.name_en,
         SubscriptionPlan.duration_months,
         SubscriptionPlan.price_stars,
@@ -291,7 +282,6 @@ class SubscriptionPlanAdmin(ModelView, model=SubscriptionPlan):
 
 class SubscriptionAdmin(ModelView, model=Subscription):
     column_list = [
-        Subscription.id,
         Subscription.user_id,
         Subscription.plan_id,
         Subscription.starts_at,
@@ -310,7 +300,6 @@ class SubscriptionAdmin(ModelView, model=Subscription):
 
 class PaymentAdmin(ModelView, model=Payment):
     column_list = [
-        Payment.id,
         Payment.user_id,
         Payment.plan_id,
         Payment.amount_stars,
@@ -329,7 +318,6 @@ class PaymentAdmin(ModelView, model=Payment):
 
 class ReferralRewardAdmin(ModelView, model=ReferralReward):
     column_list = [
-        ReferralReward.id,
         ReferralReward.referrer_id,
         ReferralReward.referred_id,
         ReferralReward.reward_months,

--- a/app/templates/sqladmin_overrides/dashboard.html
+++ b/app/templates/sqladmin_overrides/dashboard.html
@@ -1,0 +1,198 @@
+{% extends "sqladmin/layout.html" %}
+
+{% block content_header %}
+<div class="row align-items-center">
+    <div class="col">
+        <h2 class="page-title">Dashboard</h2>
+        <div class="page-pretitle">Noteme overview</div>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="row row-deck row-cards">
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Total users</div>
+                </div>
+                <div class="h1 mb-0">{{ total_users }}</div>
+                <div class="text-muted mt-1">
+                    +{{ new_users_7d }} (7d) / +{{ new_users_30d }} (30d)
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Stars earned</div>
+                </div>
+                <div class="h1 mb-0">{{ total_stars }}</div>
+                <div class="text-muted mt-1">
+                    Paying: {{ paying_users }} / Free: {{ free_users }}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Events</div>
+                </div>
+                <div class="h1 mb-0">{{ total_events }}</div>
+                <div class="text-muted mt-1">
+                    avg {{ avg_events }} per user
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Wishes</div>
+                </div>
+                <div class="h1 mb-0">{{ total_wishes }}</div>
+                <div class="text-muted mt-1">
+                    avg {{ avg_wishes }} per user / ratio {{ wish_event_ratio }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-3">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">User growth (30 days)</h3>
+            </div>
+            <div class="card-body">
+                <canvas id="growthChart" height="80"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-3">
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">User split</h3>
+            </div>
+            <div class="card-body d-flex justify-content-center">
+                <div style="max-width:300px;width:100%">
+                    <canvas id="splitChart"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Key metrics</h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table card-table table-vcenter">
+                    <tbody>
+                        <tr>
+                            <td>Total users</td>
+                            <td class="text-end"><strong>{{ total_users }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>New users (7 days)</td>
+                            <td class="text-end"><strong>{{ new_users_7d }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>New users (30 days)</td>
+                            <td class="text-end"><strong>{{ new_users_30d }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Paying users</td>
+                            <td class="text-end"><strong>{{ paying_users }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Free users</td>
+                            <td class="text-end"><strong>{{ free_users }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Total stars</td>
+                            <td class="text-end"><strong>{{ total_stars }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Total events</td>
+                            <td class="text-end"><strong>{{ total_events }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Total wishes</td>
+                            <td class="text-end"><strong>{{ total_wishes }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Avg events per user</td>
+                            <td class="text-end"><strong>{{ avg_events }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Avg wishes per user</td>
+                            <td class="text-end"><strong>{{ avg_wishes }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>Wishes/events ratio</td>
+                            <td class="text-end"><strong>{{ wish_event_ratio }}</strong></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script>
+    var growthLabels = {{ growth_labels | tojson }};
+    var growthData = {{ growth_data | tojson }};
+
+    new Chart(document.getElementById('growthChart'), {
+        type: 'line',
+        data: {
+            labels: growthLabels,
+            datasets: [{
+                label: 'Users',
+                data: growthData,
+                borderColor: '#0d6efd',
+                backgroundColor: 'rgba(13,110,253,0.1)',
+                fill: true,
+                tension: 0.3,
+                pointRadius: 3
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: { legend: { display: false } },
+            scales: {
+                y: { beginAtZero: false, ticks: { precision: 0 } }
+            }
+        }
+    });
+
+    new Chart(document.getElementById('splitChart'), {
+        type: 'doughnut',
+        data: {
+            labels: ['Paying', 'Free'],
+            datasets: [{
+                data: [{{ paying_users }}, {{ free_users }}],
+                backgroundColor: ['#198754', '#6c757d']
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'bottom' }
+            }
+        }
+    });
+</script>
+{% endblock %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,127 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+_bot_module = types.ModuleType("app.bot")
+_bot_module.bot = MagicMock()
+if "app.bot" not in sys.modules:
+    sys.modules["app.bot"] = _bot_module
+
+
+class TestAdminViewsNoId:
+    def test_user_admin_no_id_in_column_list(self):
+        from app.admin.views import UserAdmin
+        from app.models.user import User
+
+        assert User.id not in UserAdmin.column_list
+
+    def test_user_admin_id_in_details(self):
+        from app.admin.views import UserAdmin
+        from app.models.user import User
+
+        assert User.id in UserAdmin.column_details_list
+
+    def test_event_admin_no_id(self):
+        from app.admin.views import EventAdmin
+        from app.models.event import Event
+
+        assert Event.id not in EventAdmin.column_list
+
+    def test_wish_admin_no_id(self):
+        from app.admin.views import WishAdmin
+        from app.models.wish import Wish
+
+        assert Wish.id not in WishAdmin.column_list
+
+    def test_person_admin_no_id(self):
+        from app.admin.views import PersonAdmin
+        from app.models.person import Person
+
+        assert Person.id not in PersonAdmin.column_list
+
+    def test_strategy_admin_no_id(self):
+        from app.admin.views import BeautifulDateStrategyAdmin
+        from app.models.beautiful_date_strategy import BeautifulDateStrategy
+
+        assert BeautifulDateStrategy.id not in BeautifulDateStrategyAdmin.column_list
+
+    def test_beautiful_date_admin_no_id(self):
+        from app.admin.views import BeautifulDateAdmin
+        from app.models.beautiful_date import BeautifulDate
+
+        assert BeautifulDate.id not in BeautifulDateAdmin.column_list
+
+    def test_notification_log_admin_no_id(self):
+        from app.admin.views import NotificationLogAdmin
+        from app.models.notification_log import NotificationLog
+
+        assert NotificationLog.id not in NotificationLogAdmin.column_list
+
+    def test_ai_log_admin_no_id(self):
+        from app.admin.views import AILogAdmin
+        from app.models.ai_log import AILog
+
+        assert AILog.id not in AILogAdmin.column_list
+
+    def test_user_action_log_admin_no_id(self):
+        from app.admin.views import UserActionLogAdmin
+        from app.models.user_action_log import UserActionLog
+
+        assert UserActionLog.id not in UserActionLogAdmin.column_list
+
+    def test_subscription_plan_admin_no_id(self):
+        from app.admin.views import SubscriptionPlanAdmin
+        from app.models.subscription_plan import SubscriptionPlan
+
+        assert SubscriptionPlan.id not in SubscriptionPlanAdmin.column_list
+
+    def test_subscription_admin_no_id(self):
+        from app.admin.views import SubscriptionAdmin
+        from app.models.subscription import Subscription
+
+        assert Subscription.id not in SubscriptionAdmin.column_list
+
+    def test_payment_admin_no_id(self):
+        from app.admin.views import PaymentAdmin
+        from app.models.payment import Payment
+
+        assert Payment.id not in PaymentAdmin.column_list
+
+    def test_referral_reward_admin_no_id(self):
+        from app.admin.views import ReferralRewardAdmin
+        from app.models.referral_reward import ReferralReward
+
+        assert ReferralReward.id not in ReferralRewardAdmin.column_list
+
+    def test_media_link_admin_no_id(self):
+        from app.admin.views import MediaLinkAdmin
+        from app.models.media_link import MediaLink
+
+        assert MediaLink.id not in MediaLinkAdmin.column_list
+
+
+class TestUserAdminFormatter:
+    def test_username_formatter_has_action_buttons(self):
+        from app.admin.views import UserAdmin
+        from app.models.user import User
+
+        formatter = UserAdmin.column_formatters[User.username]
+        user = MagicMock()
+        user.id = 123
+        user.username = "test_user"
+        result = str(formatter(user, None))
+        assert "test_user" in result
+        assert "test-notify/123" in result
+        assert "grant-premium/123" in result
+
+    def test_username_formatter_handles_none(self):
+        from app.admin.views import UserAdmin
+        from app.models.user import User
+
+        formatter = UserAdmin.column_formatters[User.username]
+        user = MagicMock()
+        user.id = 456
+        user.username = None
+        result = str(formatter(user, None))
+        assert "-" in result
+        assert "test-notify/456" in result


### PR DESCRIPTION
## Summary
- Added admin dashboard page at /admin/dashboard with key metrics: total users, new users (7d/30d), paying vs free users, total stars earned, events/wishes counts, averages and ratios
- User growth chart (30 days) via Chart.js and paying/free doughnut chart
- Dashboard menu item added at the top of admin sidebar
- Removed `id` column from list views in all 14 admin entities (id remains visible in detail views)
- Moved User action buttons (Test/Premium) from id column to username column

Closes #39

## Test plan
- [x] 17 new tests: id absence in all column_list, id presence in details, username formatter with action buttons
- [x] Full test suite: 542 passed, 1 skipped
- [x] Linter: all checks passed