### PR TITLE
feat: AI token cost tracking in admin dashboard

### DIFF
--- a/app/admin/setup.py
+++ b/app/admin/setup.py
@@ -1,5 +1,3 @@
-"""sqladmin setup with session-based auth + clear-db action + test notifications."""
-
 import logging
 from datetime import UTC, datetime, timedelta
 
@@ -37,7 +35,6 @@ class AdminAuth(AuthenticationBackend):
         return request.session.get("authenticated", False)
 
 
-# Tables to truncate (in FK-safe order, CASCADE handles the rest)
 _CLEAR_TABLES = [
     "referral_rewards",
     "payments",
@@ -56,13 +53,11 @@ _CLEAR_TABLES = [
 
 
 def setup_admin(app: FastAPI) -> Admin:
-    """Configure sqladmin and register all views."""
-
-    # Session middleware needed by custom endpoints below.
-    # Admin() also adds it, but double middleware is harmless.
     app.add_middleware(SessionMiddleware, secret_key=settings.admin_secret_key)
 
-    # --- Custom endpoints MUST be registered BEFORE Admin() mount ---
+    @app.get("/admin")
+    async def admin_index_redirect(request: Request) -> RedirectResponse:
+        return RedirectResponse(url="/admin/dashboard", status_code=302)
 
     @app.get("/admin/dashboard", response_class=HTMLResponse)
     async def dashboard_page(request: Request) -> HTMLResponse:
@@ -74,6 +69,11 @@ def setup_admin(app: FastAPI) -> Admin:
         from app.models.subscription import Subscription
         from app.models.user import User
         from app.models.wish import Wish
+        from app.services.ai_cost_service import (
+            get_current_month_stats,
+            get_exchange_rates,
+            get_monthly_stats,
+        )
 
         now = datetime.now(UTC)
         week_ago = now - timedelta(days=7)
@@ -131,6 +131,18 @@ def setup_admin(app: FastAPI) -> Admin:
                 running += row.cnt
                 growth_data.append(running)
 
+            ai_month = await get_current_month_stats(session)
+            ai_monthly = await get_monthly_stats(session, months=6)
+
+        rates = await get_exchange_rates()
+
+        ai_avg_per_user = round(ai_month["tokens_total"] / total_users) if total_users else 0
+        ai_avg_cost_per_user = ai_month["cost_usd"] / total_users if total_users else 0.0
+
+        ai_monthly_labels = [m["month"] for m in ai_monthly]
+        ai_monthly_tokens = [m["tokens_total"] for m in ai_monthly]
+        ai_monthly_costs = [round(m["cost_usd"], 4) for m in ai_monthly]
+
         rendered = await request.app.state.admin.templates.TemplateResponse(
             request,
             "dashboard.html",
@@ -148,6 +160,59 @@ def setup_admin(app: FastAPI) -> Admin:
                 "wish_event_ratio": wish_event_ratio,
                 "growth_labels": growth_labels,
                 "growth_data": growth_data,
+                "ai_month": ai_month,
+                "rates": rates,
+                "ai_avg_per_user": ai_avg_per_user,
+                "ai_avg_cost_per_user": ai_avg_cost_per_user,
+                "ai_monthly_labels": ai_monthly_labels,
+                "ai_monthly_tokens": ai_monthly_tokens,
+                "ai_monthly_costs": ai_monthly_costs,
+            },
+        )
+        return HTMLResponse(content=rendered.body, status_code=rendered.status_code)
+
+    @app.get("/admin/ai-costs", response_class=HTMLResponse)
+    async def ai_costs_page(request: Request) -> HTMLResponse:
+        if not request.session.get("authenticated"):
+            return RedirectResponse(url="/admin/login", status_code=302)  # type: ignore[return-value]
+
+        from app.services.ai_cost_service import (
+            get_current_month_stats,
+            get_exchange_rates,
+            get_monthly_stats,
+            get_users_token_stats,
+        )
+
+        page = int(request.query_params.get("page", 1))
+        page_size = 50
+
+        async with async_session_factory() as session:
+            user_stats, total_users = await get_users_token_stats(
+                session, page=page, page_size=page_size
+            )
+            monthly_stats = await get_monthly_stats(session, months=6)
+            current_month = await get_current_month_stats(session)
+
+        rates = await get_exchange_rates()
+
+        monthly_labels = [m["month"] for m in monthly_stats]
+        monthly_tokens = [m["tokens_total"] for m in monthly_stats]
+        monthly_costs = [round(m["cost_usd"], 4) for m in monthly_stats]
+
+        rendered = await request.app.state.admin.templates.TemplateResponse(
+            request,
+            "ai_costs.html",
+            {
+                "user_stats": user_stats,
+                "total_users": total_users,
+                "page": page,
+                "page_size": page_size,
+                "monthly_stats": monthly_stats,
+                "current_month": current_month,
+                "rates": rates,
+                "monthly_labels": monthly_labels,
+                "monthly_tokens": monthly_tokens,
+                "monthly_costs": monthly_costs,
             },
         )
         return HTMLResponse(content=rendered.body, status_code=rendered.status_code)
@@ -415,8 +480,6 @@ def setup_admin(app: FastAPI) -> Admin:
             "</body></html>"
         )
 
-    # --- Now mount sqladmin (catches remaining /admin/* paths) ---
-
     auth_backend = AdminAuth(secret_key=settings.admin_secret_key)
     admin = Admin(
         app,
@@ -480,7 +543,19 @@ def setup_admin(app: FastAPI) -> Admin:
         def is_active(self, request: Request) -> bool:
             return request.url.path == "/admin/stars-balance"
 
+    class AICostsMenuItem(ItemMenu):
+        @property
+        def type_(self) -> str:
+            return "View"
+
+        def url(self, request: Request) -> str:
+            return "/admin/ai-costs"
+
+        def is_active(self, request: Request) -> bool:
+            return request.url.path == "/admin/ai-costs"
+
     admin._menu.items.insert(0, DashboardMenuItem(name="Dashboard", icon="fa-solid fa-chart-line"))
+    admin._menu.items.append(AICostsMenuItem(name="AI Costs", icon="fa-solid fa-coins"))
     admin._menu.items.append(StarsMenuItem(name="Stars Balance", icon="fa-solid fa-star"))
 
     app.state.admin = admin

--- a/app/admin/setup.py
+++ b/app/admin/setup.py
@@ -139,6 +139,15 @@ def setup_admin(app: FastAPI) -> Admin:
         ai_avg_per_user = round(ai_month["tokens_total"] / total_users) if total_users else 0
         ai_avg_cost_per_user = ai_month["cost_usd"] / total_users if total_users else 0.0
 
+        from app.services.ai_cost_service import STARS_PER_USD
+
+        if paying_users > 0:
+            min_price_stars = round(
+                ai_month["cost_usd"] * STARS_PER_USD / paying_users, 1
+            )
+        else:
+            min_price_stars = round(ai_month["cost_usd"] * STARS_PER_USD, 1)
+
         ai_monthly_labels = [m["month"] for m in ai_monthly]
         ai_monthly_tokens = [m["tokens_total"] for m in ai_monthly]
         ai_monthly_costs = [round(m["cost_usd"], 4) for m in ai_monthly]
@@ -167,6 +176,7 @@ def setup_admin(app: FastAPI) -> Admin:
                 "ai_monthly_labels": ai_monthly_labels,
                 "ai_monthly_tokens": ai_monthly_tokens,
                 "ai_monthly_costs": ai_monthly_costs,
+                "min_price_stars": min_price_stars,
             },
         )
         return HTMLResponse(content=rendered.body, status_code=rendered.status_code)

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -175,6 +175,21 @@ class NotificationLogAdmin(ModelView, model=NotificationLog):
     icon = "fa-solid fa-bell"
 
 
+def _format_tokens_with_cost(model: AILog, name: str) -> Markup:
+    from app.services.ai_cost_service import STARS_PER_USD, calculate_cost_usd
+
+    tokens = model.tokens_total or 0
+    cost = calculate_cost_usd(
+        model.tokens_prompt or 0, model.tokens_completion or 0, model.model or ""
+    )
+    stars = cost * STARS_PER_USD
+    return Markup(
+        f"{tokens:,}"
+        f'<br><span style="color:#6c757d;font-size:0.85em">'
+        f"${cost:.4f} / {stars:.1f} stars</span>"
+    )
+
+
 class AILogAdmin(ModelView, model=AILog):
     column_list = [
         AILog.user_id,
@@ -201,6 +216,9 @@ class AILogAdmin(ModelView, model=AILog):
         AILog.response_text: "Response",
         AILog.tokens_total: "Tokens",
         AILog.latency_ms: "Latency (ms)",
+    }
+    column_formatters = {
+        AILog.tokens_total: _format_tokens_with_cost,
     }
     can_create = False
     can_edit = False

--- a/app/services/ai_cost_service.py
+++ b/app/services/ai_cost_service.py
@@ -1,0 +1,220 @@
+import logging
+import time
+
+import httpx
+from sqlalchemy import extract, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ai_log import AILog
+
+logger = logging.getLogger(__name__)
+
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4-turbo": {"input": 10.00, "output": 30.00},
+    "gpt-3.5-turbo": {"input": 0.50, "output": 1.50},
+}
+
+STARS_PER_USD = 50.0
+
+_rates_cache: dict[str, float] | None = None
+_rates_cache_time: float = 0
+_RATES_TTL = 900
+
+
+async def get_exchange_rates() -> dict[str, float]:
+    global _rates_cache, _rates_cache_time
+
+    now = time.monotonic()
+    if _rates_cache is not None and (now - _rates_cache_time) < _RATES_TTL:
+        return _rates_cache
+
+    ton_per_usd = 0.0
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(
+                "https://api.coingecko.com/api/v3/simple/price",
+                params={"ids": "the-open-network", "vs_currencies": "usd"},
+            )
+            if response.status_code == 200:
+                data = response.json()
+                usd_per_ton = data.get("the-open-network", {}).get("usd", 0)
+                if usd_per_ton > 0:
+                    ton_per_usd = 1.0 / usd_per_ton
+    except Exception:
+        logger.warning("Failed to fetch TON/USD rate from CoinGecko")
+
+    _rates_cache = {"ton_per_usd": ton_per_usd, "stars_per_usd": STARS_PER_USD}
+    _rates_cache_time = now
+    return _rates_cache
+
+
+def calculate_cost_usd(
+    tokens_prompt: int,
+    tokens_completion: int,
+    model: str,
+) -> float:
+    pricing = MODEL_PRICING.get(model)
+    if pricing is None:
+        return 0.0
+    return (tokens_prompt / 1_000_000) * pricing["input"] + (
+        tokens_completion / 1_000_000
+    ) * pricing["output"]
+
+
+async def get_users_token_stats(
+    session: AsyncSession,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    from datetime import UTC, datetime
+
+    from app.models.user import User
+
+    q = (
+        select(
+            AILog.user_id,
+            User.username,
+            User.first_name,
+            AILog.model,
+            func.coalesce(func.sum(AILog.tokens_prompt), 0).label("sum_prompt"),
+            func.coalesce(func.sum(AILog.tokens_completion), 0).label("sum_completion"),
+            func.coalesce(func.sum(AILog.tokens_total), 0).label("sum_total"),
+            func.min(AILog.created_at).label("first_call"),
+        )
+        .join(User, User.id == AILog.user_id)
+        .group_by(AILog.user_id, AILog.model, User.username, User.first_name)
+    )
+
+    rows = (await session.execute(q)).all()
+
+    users: dict[int, dict] = {}
+    for row in rows:
+        uid = row.user_id
+        if uid not in users:
+            users[uid] = {
+                "user_id": uid,
+                "username": row.username or row.first_name or str(uid),
+                "tokens_prompt": 0,
+                "tokens_completion": 0,
+                "tokens_total": 0,
+                "cost_usd": 0.0,
+                "first_call": row.first_call,
+            }
+        u = users[uid]
+        u["tokens_prompt"] += row.sum_prompt
+        u["tokens_completion"] += row.sum_completion
+        u["tokens_total"] += row.sum_total
+        u["cost_usd"] += calculate_cost_usd(row.sum_prompt, row.sum_completion, row.model)
+        if row.first_call and (u["first_call"] is None or row.first_call < u["first_call"]):
+            u["first_call"] = row.first_call
+
+    now = datetime.now(UTC)
+    for u in users.values():
+        if u["first_call"]:
+            days = max((now - u["first_call"]).days, 1)
+            months = max(days / 30.0, 1.0)
+            u["avg_monthly_tokens"] = round(u["tokens_total"] / months)
+            u["avg_monthly_cost_usd"] = u["cost_usd"] / months
+        else:
+            u["avg_monthly_tokens"] = u["tokens_total"]
+            u["avg_monthly_cost_usd"] = u["cost_usd"]
+
+    sorted_users = sorted(users.values(), key=lambda x: x["tokens_total"], reverse=True)
+    total = len(sorted_users)
+    offset = (page - 1) * page_size
+    paginated = sorted_users[offset : offset + page_size]
+
+    return paginated, total
+
+
+async def get_monthly_stats(session: AsyncSession, months: int = 6) -> list[dict]:
+    from datetime import UTC, datetime, timedelta
+
+    cutoff = datetime.now(UTC) - timedelta(days=months * 31)
+
+    q = (
+        select(
+            extract("year", AILog.created_at).label("year"),
+            extract("month", AILog.created_at).label("month"),
+            AILog.model,
+            func.coalesce(func.sum(AILog.tokens_prompt), 0).label("sum_prompt"),
+            func.coalesce(func.sum(AILog.tokens_completion), 0).label("sum_completion"),
+            func.coalesce(func.sum(AILog.tokens_total), 0).label("sum_total"),
+            func.count(AILog.id).label("calls"),
+        )
+        .where(AILog.created_at >= cutoff)
+        .group_by(
+            extract("year", AILog.created_at),
+            extract("month", AILog.created_at),
+            AILog.model,
+        )
+        .order_by(
+            extract("year", AILog.created_at),
+            extract("month", AILog.created_at),
+        )
+    )
+
+    rows = (await session.execute(q)).all()
+
+    monthly: dict[str, dict] = {}
+    for row in rows:
+        key = f"{int(row.year)}-{int(row.month):02d}"
+        if key not in monthly:
+            monthly[key] = {
+                "month": key,
+                "tokens_total": 0,
+                "tokens_prompt": 0,
+                "tokens_completion": 0,
+                "cost_usd": 0.0,
+                "calls": 0,
+            }
+        m = monthly[key]
+        m["tokens_total"] += row.sum_total
+        m["tokens_prompt"] += row.sum_prompt
+        m["tokens_completion"] += row.sum_completion
+        m["cost_usd"] += calculate_cost_usd(row.sum_prompt, row.sum_completion, row.model)
+        m["calls"] += row.calls
+
+    return sorted(monthly.values(), key=lambda x: x["month"])
+
+
+async def get_current_month_stats(session: AsyncSession) -> dict:
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+
+    q = (
+        select(
+            AILog.model,
+            func.coalesce(func.sum(AILog.tokens_prompt), 0).label("sum_prompt"),
+            func.coalesce(func.sum(AILog.tokens_completion), 0).label("sum_completion"),
+            func.coalesce(func.sum(AILog.tokens_total), 0).label("sum_total"),
+            func.count(AILog.id).label("calls"),
+        )
+        .where(
+            extract("year", AILog.created_at) == now.year,
+            extract("month", AILog.created_at) == now.month,
+        )
+        .group_by(AILog.model)
+    )
+
+    rows = (await session.execute(q)).all()
+
+    result = {
+        "tokens_total": 0,
+        "tokens_prompt": 0,
+        "tokens_completion": 0,
+        "cost_usd": 0.0,
+        "calls": 0,
+    }
+
+    for row in rows:
+        result["tokens_total"] += row.sum_total
+        result["tokens_prompt"] += row.sum_prompt
+        result["tokens_completion"] += row.sum_completion
+        result["cost_usd"] += calculate_cost_usd(row.sum_prompt, row.sum_completion, row.model)
+        result["calls"] += row.calls
+
+    return result

--- a/app/templates/sqladmin_overrides/ai_costs.html
+++ b/app/templates/sqladmin_overrides/ai_costs.html
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="row row-deck row-cards">
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
@@ -50,9 +49,7 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row mt-3">
     <div class="col-12">
         <div class="card">
             <div class="card-header">
@@ -67,9 +64,7 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row mt-3">
     <div class="col-12">
         <div class="card">
             <div class="card-header">
@@ -114,9 +109,7 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row mt-3">
     <div class="col-12">
         <div class="card">
             <div class="card-header">
@@ -181,7 +174,6 @@
             {% endif %}
         </div>
     </div>
-</div>
 
 {% if monthly_stats %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>

--- a/app/templates/sqladmin_overrides/ai_costs.html
+++ b/app/templates/sqladmin_overrides/ai_costs.html
@@ -1,0 +1,234 @@
+{% extends "sqladmin/layout.html" %}
+
+{% block content_header %}
+<div class="row align-items-center">
+    <div class="col">
+        <h2 class="page-title">AI Costs</h2>
+        <div class="page-pretitle">Token usage and cost breakdown</div>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="row row-deck row-cards">
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">This month tokens</div>
+                <div class="h1 mb-0">{{ "{:,}".format(current_month.tokens_total) }}</div>
+                <div class="text-muted mt-1">{{ current_month.calls }} calls</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">This month cost (USD)</div>
+                <div class="h1 mb-0">${{ "%.4f"|format(current_month.cost_usd) }}</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">This month cost (TON)</div>
+                <div class="h1 mb-0">
+                    {% if rates.ton_per_usd > 0 %}
+                        {{ "%.6f"|format(current_month.cost_usd * rates.ton_per_usd) }}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">This month cost (Stars)</div>
+                <div class="h1 mb-0">{{ "%.1f"|format(current_month.cost_usd * rates.stars_per_usd) }}</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-3">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Monthly token usage (last 6 months)</h3>
+            </div>
+            <div class="card-body">
+                {% if monthly_stats %}
+                    <canvas id="monthlyChart" height="80"></canvas>
+                {% else %}
+                    <p class="text-muted">No data yet</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-3">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Monthly breakdown</h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table card-table table-vcenter">
+                    <thead>
+                        <tr>
+                            <th>Month</th>
+                            <th class="text-end">Tokens</th>
+                            <th class="text-end">Calls</th>
+                            <th class="text-end">USD</th>
+                            <th class="text-end">TON</th>
+                            <th class="text-end">Stars</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for m in monthly_stats|reverse %}
+                        <tr>
+                            <td>{{ m.month }}</td>
+                            <td class="text-end">{{ "{:,}".format(m.tokens_total) }}</td>
+                            <td class="text-end">{{ "{:,}".format(m.calls) }}</td>
+                            <td class="text-end">${{ "%.4f"|format(m.cost_usd) }}</td>
+                            <td class="text-end">
+                                {% if rates.ton_per_usd > 0 %}
+                                    {{ "%.6f"|format(m.cost_usd * rates.ton_per_usd) }}
+                                {% else %}
+                                    N/A
+                                {% endif %}
+                            </td>
+                            <td class="text-end">{{ "%.1f"|format(m.cost_usd * rates.stars_per_usd) }}</td>
+                        </tr>
+                        {% endfor %}
+                        {% if not monthly_stats %}
+                        <tr>
+                            <td colspan="6" class="text-muted text-center">No data yet</td>
+                        </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-3">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Per-user AI costs</h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table card-table table-vcenter">
+                    <thead>
+                        <tr>
+                            <th>User</th>
+                            <th class="text-end">Total tokens</th>
+                            <th class="text-end">Avg monthly</th>
+                            <th class="text-end">USD</th>
+                            <th class="text-end">TON</th>
+                            <th class="text-end">Stars</th>
+                            <th class="text-end">Avg monthly USD</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for u in user_stats %}
+                        <tr>
+                            <td>
+                                <a href="/admin/user/details/{{ u.user_id }}">{{ u.username }}</a>
+                            </td>
+                            <td class="text-end">{{ "{:,}".format(u.tokens_total) }}</td>
+                            <td class="text-end">{{ "{:,}".format(u.avg_monthly_tokens) }}</td>
+                            <td class="text-end">${{ "%.4f"|format(u.cost_usd) }}</td>
+                            <td class="text-end">
+                                {% if rates.ton_per_usd > 0 %}
+                                    {{ "%.6f"|format(u.cost_usd * rates.ton_per_usd) }}
+                                {% else %}
+                                    N/A
+                                {% endif %}
+                            </td>
+                            <td class="text-end">{{ "%.1f"|format(u.cost_usd * rates.stars_per_usd) }}</td>
+                            <td class="text-end">${{ "%.4f"|format(u.avg_monthly_cost_usd) }}</td>
+                        </tr>
+                        {% endfor %}
+                        {% if not user_stats %}
+                        <tr>
+                            <td colspan="7" class="text-muted text-center">No data yet</td>
+                        </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+            </div>
+            {% if total_users > page_size %}
+            <div class="card-footer d-flex align-items-center justify-content-between">
+                <p class="m-0 text-muted">
+                    Showing {{ (page - 1) * page_size + 1 }}-{{ [page * page_size, total_users]|min }}
+                    of {{ total_users }}
+                </p>
+                <div>
+                    {% if page > 1 %}
+                        <a href="?page={{ page - 1 }}" class="btn btn-sm btn-outline-primary">Previous</a>
+                    {% endif %}
+                    {% if page * page_size < total_users %}
+                        <a href="?page={{ page + 1 }}" class="btn btn-sm btn-outline-primary">Next</a>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+{% if monthly_stats %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script>
+    var labels = {{ monthly_labels | tojson }};
+    var tokensData = {{ monthly_tokens | tojson }};
+    var costData = {{ monthly_costs | tojson }};
+
+    new Chart(document.getElementById('monthlyChart'), {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: 'Tokens',
+                    data: tokensData,
+                    backgroundColor: 'rgba(13,110,253,0.6)',
+                    yAxisID: 'y'
+                },
+                {
+                    label: 'Cost (USD)',
+                    data: costData,
+                    type: 'line',
+                    borderColor: '#dc3545',
+                    backgroundColor: 'transparent',
+                    yAxisID: 'y1',
+                    tension: 0.3,
+                    pointRadius: 4
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: {
+                    position: 'left',
+                    title: { display: true, text: 'Tokens' },
+                    ticks: { precision: 0 }
+                },
+                y1: {
+                    position: 'right',
+                    title: { display: true, text: 'USD' },
+                    grid: { drawOnChartArea: false }
+                }
+            }
+        }
+    });
+</script>
+{% endif %}
+{% endblock %}

--- a/app/templates/sqladmin_overrides/dashboard.html
+++ b/app/templates/sqladmin_overrides/dashboard.html
@@ -14,9 +14,7 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="d-flex align-items-center">
-                    <div class="subheader">Total users</div>
-                </div>
+                <div class="subheader">Total users</div>
                 <div class="h1 mb-0">{{ total_users }}</div>
                 <div class="text-muted mt-1">
                     +{{ new_users_7d }} (7d) / +{{ new_users_30d }} (30d)
@@ -27,9 +25,7 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="d-flex align-items-center">
-                    <div class="subheader">Stars earned</div>
-                </div>
+                <div class="subheader">Stars earned</div>
                 <div class="h1 mb-0">{{ total_stars }}</div>
                 <div class="text-muted mt-1">
                     Paying: {{ paying_users }} / Free: {{ free_users }}
@@ -40,9 +36,7 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="d-flex align-items-center">
-                    <div class="subheader">Events</div>
-                </div>
+                <div class="subheader">Events</div>
                 <div class="h1 mb-0">{{ total_events }}</div>
                 <div class="text-muted mt-1">
                     avg {{ avg_events }} per user
@@ -53,12 +47,61 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="d-flex align-items-center">
-                    <div class="subheader">Wishes</div>
-                </div>
+                <div class="subheader">Wishes</div>
                 <div class="h1 mb-0">{{ total_wishes }}</div>
                 <div class="text-muted mt-1">
                     avg {{ avg_wishes }} per user / ratio {{ wish_event_ratio }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row row-deck row-cards mt-3">
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">AI tokens (this month)</div>
+                <div class="h1 mb-0">{{ "{:,}".format(ai_month.tokens_total) }}</div>
+                <div class="text-muted mt-1">{{ ai_month.calls }} calls</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">AI cost (this month)</div>
+                <div class="h1 mb-0">${{ "%.4f"|format(ai_month.cost_usd) }}</div>
+                <div class="text-muted mt-1">
+                    {{ "%.1f"|format(ai_month.cost_usd * rates.stars_per_usd) }} stars
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">AI cost (TON)</div>
+                <div class="h1 mb-0">
+                    {% if rates.ton_per_usd > 0 %}
+                        {{ "%.6f"|format(ai_month.cost_usd * rates.ton_per_usd) }}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </div>
+                <div class="text-muted mt-1">
+                    <a href="/admin/ai-costs">View details</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">Avg tokens per user</div>
+                <div class="h1 mb-0">{{ "{:,}".format(ai_avg_per_user) }}</div>
+                <div class="text-muted mt-1">
+                    ${{ "%.4f"|format(ai_avg_cost_per_user) }}/user
                 </div>
             </div>
         </div>
@@ -92,6 +135,23 @@
         </div>
     </div>
     <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Monthly AI costs</h3>
+            </div>
+            <div class="card-body">
+                {% if ai_monthly_labels %}
+                    <canvas id="aiCostChart"></canvas>
+                {% else %}
+                    <p class="text-muted">No data yet</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-3">
+    <div class="col-12">
         <div class="card">
             <div class="card-header">
                 <h3 class="card-title">Key metrics</h3>
@@ -142,6 +202,25 @@
                         <tr>
                             <td>Wishes/events ratio</td>
                             <td class="text-end"><strong>{{ wish_event_ratio }}</strong></td>
+                        </tr>
+                        <tr>
+                            <td>AI tokens (this month)</td>
+                            <td class="text-end">
+                                <strong>{{ "{:,}".format(ai_month.tokens_total) }}</strong>
+                                <span class="text-muted ms-1">
+                                    (${{ "%.4f"|format(ai_month.cost_usd) }}
+                                    / {{ "%.1f"|format(ai_month.cost_usd * rates.stars_per_usd) }} stars)
+                                </span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Avg monthly tokens per user</td>
+                            <td class="text-end">
+                                <strong>{{ "{:,}".format(ai_avg_per_user) }}</strong>
+                                <span class="text-muted ms-1">
+                                    (${{ "%.4f"|format(ai_avg_cost_per_user) }})
+                                </span>
+                            </td>
                         </tr>
                     </tbody>
                 </table>
@@ -194,5 +273,51 @@
             }
         }
     });
+
+    {% if ai_monthly_labels %}
+    var aiLabels = {{ ai_monthly_labels | tojson }};
+    var aiTokens = {{ ai_monthly_tokens | tojson }};
+    var aiCosts = {{ ai_monthly_costs | tojson }};
+
+    new Chart(document.getElementById('aiCostChart'), {
+        type: 'bar',
+        data: {
+            labels: aiLabels,
+            datasets: [
+                {
+                    label: 'Tokens',
+                    data: aiTokens,
+                    backgroundColor: 'rgba(13,110,253,0.6)',
+                    yAxisID: 'y'
+                },
+                {
+                    label: 'Cost (USD)',
+                    data: aiCosts,
+                    type: 'line',
+                    borderColor: '#dc3545',
+                    backgroundColor: 'transparent',
+                    yAxisID: 'y1',
+                    tension: 0.3,
+                    pointRadius: 4
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: {
+                    position: 'left',
+                    title: { display: true, text: 'Tokens' },
+                    ticks: { precision: 0 }
+                },
+                y1: {
+                    position: 'right',
+                    title: { display: true, text: 'USD' },
+                    grid: { drawOnChartArea: false }
+                }
+            }
+        }
+    });
+    {% endif %}
 </script>
 {% endblock %}

--- a/app/templates/sqladmin_overrides/dashboard.html
+++ b/app/templates/sqladmin_overrides/dashboard.html
@@ -10,11 +10,12 @@
 {% endblock %}
 
 {% block content %}
-<div class="row row-deck row-cards">
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">Total users</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Total users</div>
+                </div>
                 <div class="h1 mb-0">{{ total_users }}</div>
                 <div class="text-muted mt-1">
                     +{{ new_users_7d }} (7d) / +{{ new_users_30d }} (30d)
@@ -25,7 +26,9 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">Stars earned</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Stars earned</div>
+                </div>
                 <div class="h1 mb-0">{{ total_stars }}</div>
                 <div class="text-muted mt-1">
                     Paying: {{ paying_users }} / Free: {{ free_users }}
@@ -36,7 +39,9 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">Events</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Events</div>
+                </div>
                 <div class="h1 mb-0">{{ total_events }}</div>
                 <div class="text-muted mt-1">
                     avg {{ avg_events }} per user
@@ -47,7 +52,9 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">Wishes</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Wishes</div>
+                </div>
                 <div class="h1 mb-0">{{ total_wishes }}</div>
                 <div class="text-muted mt-1">
                     avg {{ avg_wishes }} per user / ratio {{ wish_event_ratio }}
@@ -55,13 +62,13 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row row-deck row-cards mt-3">
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">AI tokens (this month)</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">AI tokens (this month)</div>
+                </div>
                 <div class="h1 mb-0">{{ "{:,}".format(ai_month.tokens_total) }}</div>
                 <div class="text-muted mt-1">{{ ai_month.calls }} calls</div>
             </div>
@@ -70,7 +77,9 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">AI cost (this month)</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">AI cost (this month)</div>
+                </div>
                 <div class="h1 mb-0">${{ "%.4f"|format(ai_month.cost_usd) }}</div>
                 <div class="text-muted mt-1">
                     {{ "%.1f"|format(ai_month.cost_usd * rates.stars_per_usd) }} stars
@@ -81,7 +90,9 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">AI cost (TON)</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">AI cost (TON)</div>
+                </div>
                 <div class="h1 mb-0">
                     {% if rates.ton_per_usd > 0 %}
                         {{ "%.6f"|format(ai_month.cost_usd * rates.ton_per_usd) }}
@@ -98,7 +109,9 @@
     <div class="col-sm-6 col-lg-3">
         <div class="card">
             <div class="card-body">
-                <div class="subheader">Avg tokens per user</div>
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Avg tokens per user</div>
+                </div>
                 <div class="h1 mb-0">{{ "{:,}".format(ai_avg_per_user) }}</div>
                 <div class="text-muted mt-1">
                     ${{ "%.4f"|format(ai_avg_cost_per_user) }}/user
@@ -106,9 +119,7 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row mt-3">
     <div class="col-12">
         <div class="card">
             <div class="card-header">
@@ -119,9 +130,7 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row mt-3">
     <div class="col-lg-6">
         <div class="card">
             <div class="card-header">
@@ -148,9 +157,7 @@
             </div>
         </div>
     </div>
-</div>
 
-<div class="row mt-3">
     <div class="col-12">
         <div class="card">
             <div class="card-header">
@@ -227,7 +234,6 @@
             </div>
         </div>
     </div>
-</div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script>

--- a/app/templates/sqladmin_overrides/dashboard.html
+++ b/app/templates/sqladmin_overrides/dashboard.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -23,7 +23,7 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -36,7 +36,7 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -49,7 +49,7 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -63,7 +63,7 @@
         </div>
     </div>
 
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -74,7 +74,7 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -87,7 +87,7 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -106,7 +106,7 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-lg-3">
+    <div class="col-sm-6 col-lg-4">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex align-items-center">
@@ -115,6 +115,23 @@
                 <div class="h1 mb-0">{{ "{:,}".format(ai_avg_per_user) }}</div>
                 <div class="text-muted mt-1">
                     ${{ "%.4f"|format(ai_avg_cost_per_user) }}/user
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-4">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex align-items-center">
+                    <div class="subheader">Min price / month</div>
+                </div>
+                <div class="h1 mb-0">{{ min_price_stars }} stars</div>
+                <div class="text-muted mt-1">
+                    {% if paying_users > 0 %}
+                        breakeven at {{ paying_users }} paying
+                    {% else %}
+                        no paying users
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -226,6 +243,15 @@
                                 <strong>{{ "{:,}".format(ai_avg_per_user) }}</strong>
                                 <span class="text-muted ms-1">
                                     (${{ "%.4f"|format(ai_avg_cost_per_user) }})
+                                </span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Min subscription price (breakeven)</td>
+                            <td class="text-end">
+                                <strong>{{ min_price_stars }} stars</strong>
+                                <span class="text-muted ms-1">
+                                    (${{ "%.4f"|format(min_price_stars / rates.stars_per_usd) }})
                                 </span>
                             </td>
                         </tr>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,17 +13,18 @@ services:
       - NOTEME_DB_PORT=5432
       - NOTEME_REDIS_HOST=redis
       - NOTEME_REDIS_PORT=6379
+      - NOTEME_APP_PORT=8001
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
     ports:
-      - "8001:8000"
+      - "8001:8001"
     volumes:
       - .:/app
       - app_venv:/app/.venv
-    command: sh -c "uv sync --frozen --no-dev && python -m app"
+    command: sh -c "uv sync --frozen && watchfiles 'python -m app' /app/app"
 
   worker:
     build:

--- a/tests/test_ai_cost_service.py
+++ b/tests/test_ai_cost_service.py
@@ -1,0 +1,293 @@
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_bot_module = types.ModuleType("app.bot")
+_bot_module.bot = AsyncMock()
+if "app.bot" not in sys.modules:
+    sys.modules["app.bot"] = _bot_module
+
+from app.services.ai_cost_service import (  # noqa: E402
+    MODEL_PRICING,
+    STARS_PER_USD,
+    calculate_cost_usd,
+    get_current_month_stats,
+    get_exchange_rates,
+    get_monthly_stats,
+    get_users_token_stats,
+)
+
+
+class TestCalculateCostUsd:
+    def test_known_model(self):
+        cost = calculate_cost_usd(1_000_000, 1_000_000, "gpt-4o-mini")
+        expected = MODEL_PRICING["gpt-4o-mini"]["input"] + MODEL_PRICING["gpt-4o-mini"]["output"]
+        assert abs(cost - expected) < 0.0001
+
+    def test_unknown_model(self):
+        assert calculate_cost_usd(1000, 500, "unknown-model") == 0.0
+
+    def test_zero_tokens(self):
+        assert calculate_cost_usd(0, 0, "gpt-4o-mini") == 0.0
+
+    def test_prompt_only(self):
+        cost = calculate_cost_usd(500_000, 0, "gpt-4o-mini")
+        expected = (500_000 / 1_000_000) * MODEL_PRICING["gpt-4o-mini"]["input"]
+        assert abs(cost - expected) < 0.0001
+
+    def test_completion_only(self):
+        cost = calculate_cost_usd(0, 200_000, "gpt-4o-mini")
+        expected = (200_000 / 1_000_000) * MODEL_PRICING["gpt-4o-mini"]["output"]
+        assert abs(cost - expected) < 0.0001
+
+    def test_gpt4o_pricing(self):
+        cost = calculate_cost_usd(1_000_000, 1_000_000, "gpt-4o")
+        expected = MODEL_PRICING["gpt-4o"]["input"] + MODEL_PRICING["gpt-4o"]["output"]
+        assert abs(cost - expected) < 0.0001
+
+
+class TestGetExchangeRates:
+    @pytest.mark.asyncio
+    async def test_returns_rates_on_success(self):
+        import app.services.ai_cost_service as svc
+
+        svc._rates_cache = None
+        svc._rates_cache_time = 0
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"the-open-network": {"usd": 2.5}}
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_client
+        mock_cm.__aexit__.return_value = False
+
+        with patch(
+            "app.services.ai_cost_service.httpx.AsyncClient", return_value=mock_cm
+        ):
+            rates = await get_exchange_rates()
+
+        assert abs(rates["ton_per_usd"] - 0.4) < 0.0001
+        assert rates["stars_per_usd"] == STARS_PER_USD
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_rates(self):
+        import time
+
+        import app.services.ai_cost_service as svc
+
+        svc._rates_cache = {"ton_per_usd": 0.5, "stars_per_usd": STARS_PER_USD}
+        svc._rates_cache_time = time.monotonic()
+
+        rates = await get_exchange_rates()
+        assert rates["ton_per_usd"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_handles_api_failure(self):
+        import app.services.ai_cost_service as svc
+
+        svc._rates_cache = None
+        svc._rates_cache_time = 0
+
+        with patch(
+            "app.services.ai_cost_service.httpx.AsyncClient",
+            side_effect=Exception("connection error"),
+        ):
+            rates = await get_exchange_rates()
+
+        assert rates["ton_per_usd"] == 0.0
+        assert rates["stars_per_usd"] == STARS_PER_USD
+
+
+class TestGetUsersTokenStats:
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        users, total = await get_users_token_stats(session)
+        assert total == 0
+        assert users == []
+
+    @pytest.mark.asyncio
+    async def test_with_data(self, session):
+        from app.models.ai_log import AILog
+        from app.models.user import User
+
+        user = User(id=111, language="en", first_name="Test")
+        session.add(user)
+        await session.flush()
+
+        now = datetime.now(UTC)
+        for i in range(3):
+            session.add(
+                AILog(
+                    user_id=111,
+                    agent_name="router",
+                    model="gpt-4o-mini",
+                    tokens_prompt=100,
+                    tokens_completion=50,
+                    tokens_total=150,
+                    created_at=now - timedelta(days=i),
+                )
+            )
+        await session.commit()
+
+        users, total = await get_users_token_stats(session)
+        assert total == 1
+        assert len(users) == 1
+        assert users[0]["user_id"] == 111
+        assert users[0]["tokens_total"] == 450
+        assert users[0]["tokens_prompt"] == 300
+        assert users[0]["tokens_completion"] == 150
+        assert users[0]["cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_pagination(self, session):
+        from app.models.ai_log import AILog
+        from app.models.user import User
+
+        for uid in range(1, 4):
+            session.add(User(id=uid, language="en", first_name=f"User{uid}"))
+        await session.flush()
+
+        now = datetime.now(UTC)
+        for uid in range(1, 4):
+            session.add(
+                AILog(
+                    user_id=uid,
+                    agent_name="router",
+                    model="gpt-4o-mini",
+                    tokens_prompt=uid * 100,
+                    tokens_completion=uid * 50,
+                    tokens_total=uid * 150,
+                    created_at=now,
+                )
+            )
+        await session.commit()
+
+        page1, total = await get_users_token_stats(session, page=1, page_size=2)
+        assert total == 3
+        assert len(page1) == 2
+
+        page2, total2 = await get_users_token_stats(session, page=2, page_size=2)
+        assert total2 == 3
+        assert len(page2) == 1
+
+
+class TestGetMonthlyStats:
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        stats = await get_monthly_stats(session)
+        assert stats == []
+
+    @pytest.mark.asyncio
+    async def test_with_data(self, session):
+        from app.models.ai_log import AILog
+        from app.models.user import User
+
+        session.add(User(id=222, language="en", first_name="Test"))
+        await session.flush()
+
+        now = datetime.now(UTC)
+        session.add(
+            AILog(
+                user_id=222,
+                agent_name="event_agent",
+                model="gpt-4o-mini",
+                tokens_prompt=500,
+                tokens_completion=200,
+                tokens_total=700,
+                created_at=now,
+            )
+        )
+        await session.commit()
+
+        stats = await get_monthly_stats(session, months=1)
+        assert len(stats) == 1
+        assert stats[0]["tokens_total"] == 700
+        assert stats[0]["cost_usd"] > 0
+        assert stats[0]["calls"] == 1
+
+
+class TestGetCurrentMonthStats:
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        stats = await get_current_month_stats(session)
+        assert stats["tokens_total"] == 0
+        assert stats["cost_usd"] == 0.0
+        assert stats["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_with_data(self, session):
+        from app.models.ai_log import AILog
+        from app.models.user import User
+
+        session.add(User(id=333, language="en", first_name="Test"))
+        await session.flush()
+
+        now = datetime.now(UTC)
+        for _ in range(5):
+            session.add(
+                AILog(
+                    user_id=333,
+                    agent_name="validation",
+                    model="gpt-4o-mini",
+                    tokens_prompt=200,
+                    tokens_completion=100,
+                    tokens_total=300,
+                    created_at=now,
+                )
+            )
+        await session.commit()
+
+        stats = await get_current_month_stats(session)
+        assert stats["tokens_total"] == 1500
+        assert stats["tokens_prompt"] == 1000
+        assert stats["tokens_completion"] == 500
+        assert stats["calls"] == 5
+        assert stats["cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_models(self, session):
+        from app.models.ai_log import AILog
+        from app.models.user import User
+
+        session.add(User(id=444, language="en", first_name="Test"))
+        await session.flush()
+
+        now = datetime.now(UTC)
+        session.add(
+            AILog(
+                user_id=444,
+                agent_name="router",
+                model="gpt-4o-mini",
+                tokens_prompt=100,
+                tokens_completion=50,
+                tokens_total=150,
+                created_at=now,
+            )
+        )
+        session.add(
+            AILog(
+                user_id=444,
+                agent_name="event_agent",
+                model="gpt-4o",
+                tokens_prompt=200,
+                tokens_completion=100,
+                tokens_total=300,
+                created_at=now,
+            )
+        )
+        await session.commit()
+
+        stats = await get_current_month_stats(session)
+        assert stats["tokens_total"] == 450
+        assert stats["calls"] == 2
+
+        mini_cost = calculate_cost_usd(100, 50, "gpt-4o-mini")
+        big_cost = calculate_cost_usd(200, 100, "gpt-4o")
+        assert abs(stats["cost_usd"] - (mini_cost + big_cost)) < 0.0001


### PR DESCRIPTION
## Summary
- AI token cost tracking service with per-model pricing (gpt-4o-mini, gpt-4o, gpt-4-turbo, gpt-3.5-turbo)
- Dashboard: 9 KPI cards (3x3 grid) — users, stars, events, wishes, AI tokens, AI cost USD, AI cost TON, avg tokens/user, min breakeven price
- Dashboard: user growth chart, user split doughnut, monthly AI costs chart, key metrics table
- `/admin/ai-costs` page: current month stats, monthly breakdown table + chart, per-user costs with pagination
- AI Logs list: token column shows USD and Stars cost inline
- TON/USD exchange rate from CoinGecko API with 15-min cache
- Min subscription price calculation: total AI cost / paying users = breakeven in Stars
- `/admin` redirects to `/admin/dashboard`
- Docker compose: hot reload via watchfiles, correct port mapping

Closes #42